### PR TITLE
Implement transliteration for program titles

### DIFF
--- a/index.php
+++ b/index.php
@@ -19,6 +19,26 @@ $client = new Client([
     'timeout' => 10.0,
 ]);
 
+function transliterate(string $text): string {
+    $map = [
+        'А' => 'A', 'Б' => 'B', 'В' => 'V', 'Г' => 'G', 'Д' => 'D',
+        'Е' => 'E', 'Ё' => 'Yo', 'Ж' => 'Zh', 'З' => 'Z', 'И' => 'I',
+        'Й' => 'Y', 'К' => 'K', 'Л' => 'L', 'М' => 'M', 'Н' => 'N',
+        'О' => 'O', 'П' => 'P', 'Р' => 'R', 'С' => 'S', 'Т' => 'T',
+        'У' => 'U', 'Ф' => 'F', 'Х' => 'Kh', 'Ц' => 'Ts', 'Ч' => 'Ch',
+        'Ш' => 'Sh', 'Щ' => 'Shch', 'Ъ' => '',  'Ы' => 'Y', 'Ь' => '',
+        'Э' => 'E', 'Ю' => 'Yu', 'Я' => 'Ya',
+        'а' => 'a', 'б' => 'b', 'в' => 'v', 'г' => 'g', 'д' => 'd',
+        'е' => 'e', 'ё' => 'yo', 'ж' => 'zh', 'з' => 'z', 'и' => 'i',
+        'й' => 'y', 'к' => 'k', 'л' => 'l', 'м' => 'm', 'н' => 'n',
+        'о' => 'o', 'п' => 'p', 'р' => 'r', 'с' => 's', 'т' => 't',
+        'у' => 'u', 'ф' => 'f', 'х' => 'kh', 'ц' => 'ts', 'ч' => 'ch',
+        'ш' => 'sh', 'щ' => 'shch', 'ъ' => '',  'ы' => 'y', 'ь' => '',
+        'э' => 'e', 'ю' => 'yu', 'я' => 'ya'
+    ];
+    return strtr($text, $map);
+}
+
 $app->get('/', function (Request $request, Response $response, array $args) use ($log, $client) {
     $queryParams = $request->getQueryParams();
     $searchTerm = $queryParams['s'] ?? '';
@@ -56,7 +76,8 @@ $app->get('/', function (Request $request, Response $response, array $args) use 
             $playableFile = $playableFiles[0];
 
             $output .= "^" . ($release['id'] ?? '0') . "^";
-            $output .= ($release['title'] ?? 'Unknown') . "^";
+            $title = $release['title'] ?? 'Unknown';
+            $output .= transliterate($title) . "^";
             $output .= ($playableFile['fileName'] ?? 'Unknown') . "^";
             $output .= ($playableFile['size'] ?? 0) . "^";
             $output .= count($playableFiles) . "^";


### PR DESCRIPTION
## Summary
- transliterate program names when outputting search results

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846acf2b1ac8321bbbee64e24ffafcf